### PR TITLE
Remove unused install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN curl https://copr.fedoraproject.org/coprs/g/python/pypy35/repo/fedora-26/gro
 RUN dnf install -y \
     --setopt=tsflags=nodocs \
     --setopt=deltarpm=false \
-    dnf-plugins-core \
     findutils \
     jython \
     pypy-devel \


### PR DESCRIPTION
Fixup for https://github.com/frenzymadness/fedora-python-tox/pull/5

I forgot to remove this.