### PR TITLE
Revert "Temporarily go back to pypy3 from Fedora repositories"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM fedora:27
 
 LABEL maintainer="Lumír 'Frenzy' Balhar <frenzy.madness@gmail.com>"
 
+RUN curl https://copr.fedorainfracloud.org/coprs/g/python/pypy35/repo/fedora-27/group_python-pypy35-fedora-27.repo \
+    -o /etc/yum.repos.d/group_python-pypy35-fedora-27.repo
+
 RUN dnf install -y \
     --setopt=tsflags=nodocs \
     --setopt=deltarpm=false \


### PR DESCRIPTION
This reverts commit ff004e71d68b123ff8a56f3af674f022980a9e58.

I've put it back and Pypy 3 from COPR doesn't work for me.

Steps to reproduce (at least on my machine):
```shell
$ docker build -t frenzymadness/fedora-python-tox:pypy3 .
# In the middle of the output
pypy3                       x86_64 5.10.1-1.fc27     group_python-pypy35 8.6 M
pypy3-libs                  x86_64 5.10.1-1.fc27     group_python-pypy35  16 M
```
TOXENV=pypy
```shell
$ cd example_project
$ docker run --rm -it -v $PWD:/src -w /src -e TOXENV=pypy frenzymadness/fedora-python-tox:pypy3
pypy installed: cffi==1.10.1,greenlet==0.4.12,py==1.5.2,pytest==3.2.5,readline==6.2.4.1
pypy runtests: PYTHONHASHSEED='1789422360'
pypy runtests: commands[0] | pytest
========================================== test session starts ==========================================
platform linux2 -- Python 2.7.13[pypy-5.8.0-final], pytest-3.2.5, py-1.5.2, pluggy-0.4.0
rootdir: /src, inifile:
collected 10 items                                                                                       

test_fac.py ..........

======================================= 10 passed in 0.04 seconds =======================================
________________________________________________ summary ________________________________________________
  pypy: commands succeeded
  congratulations :)
```
TOXENV=pypy3
```shell
$ docker run --rm -it -v $PWD:/src -w /src -e TOXENV=pypy3 frenzymadness/fedora-python-tox:pypy3
Traceback (most recent call last):
  File "/usr/bin/tox", line 11, in <module>
    load_entry_point('tox==2.7.0', 'console_scripts', 'tox')()
  File "/usr/lib/python3.6/site-packages/tox/session.py", line 39, in main
    retcode = Session(config).runcommand()
  File "/usr/lib/python3.6/site-packages/tox/session.py", line 392, in runcommand
    return self.subcommand_test()
  File "/usr/lib/python3.6/site-packages/tox/session.py", line 543, in subcommand_test
    if self.setupenv(venv):
  File "/usr/lib/python3.6/site-packages/tox/session.py", line 461, in setupenv
    envlog.set_python_info(commandpath)
  File "/usr/lib/python3.6/site-packages/tox/result.py", line 49, in set_python_info
    "import sys; "
  File "/usr/lib/python3.6/site-packages/py/_path/local.py", line 714, in sysexec
    stdout, stderr,)
py.process.cmdexec.Error: ExecutionFailed: 1  /src/.tox/pypy3/bin/python
debug: WARNING: Library path not found, using compiled-in sys.path, with
debug: WARNING: sys.prefix = '/builddir/build/BUILD/pypy2-v5.8.0-src'
debug: WARNING: Make sure the pypy binary is kept inside its tree of files.
debug: WARNING: It is ok to create a symlink to it from somewhere else.
debug: OperationError:
debug:  operror-type: ImportError
debug:  operror-value: No module named os
```